### PR TITLE
Update error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rfm69"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Ales Musil <aedvin1@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Update error type so it actually includes original
error for SPI and OutputPin. At the same time replace
string error for enum variant.