### PR TITLE
make some buffers non-mutable

### DIFF
--- a/examples/low_power_lab_receive.rs
+++ b/examples/low_power_lab_receive.rs
@@ -41,7 +41,7 @@ fn main() {
     if packet.ack_requested() {
         let ack = Packet::new(packet.to, packet.from, Vec::new(), true, false);
         println!("{:?}", ack);
-        rfm.send(&mut ack.as_bytes()).ok().unwrap();
+        rfm.send(&ack.as_bytes()).ok().unwrap();
     }
 
     // Un-export the CS pin

--- a/examples/low_power_lab_send.rs
+++ b/examples/low_power_lab_send.rs
@@ -34,7 +34,7 @@ fn main() {
     // Prepare struct for the data
     let packet = Packet::new(10, 1, Vec::from(b"Hello, world!".as_ref()), false, true);
     println!("{:?}", packet);
-    rfm.send(&mut packet.as_bytes()).ok().unwrap();
+    rfm.send(&packet.as_bytes()).ok().unwrap();
 
     // Wait for ACK to arrive
     let mut buffer = [0; 64];

--- a/examples/send.rs
+++ b/examples/send.rs
@@ -29,9 +29,9 @@ fn main() {
         println!("Register 0x{:02x} = 0x{:02x}", index + 1, val);
     }
 
-    // Prepare buffer to store the received data
-    let mut buffer = Vec::from(b"Hello, world!".as_ref());
-    rfm.send(&mut buffer).ok().unwrap();
+    // Send a packet
+    let buffer = Vec::from(b"Hello, world!".as_ref());
+    rfm.send(&buffer).ok().unwrap();
 
     // Un-export the CS pin
     Pin::new(25).unexport().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,24 +118,21 @@ where
     /// `RegBitrateMsb (0x03), RegBitrateLsb (0x04)`.
     pub fn bit_rate(&mut self, bit_rate: f32) -> Result<(), Ecs, Espi> {
         let reg = (FOSC / bit_rate) as u16;
-        let val = reg.to_be_bytes();
-        self.write_many(Registers::BitrateMsb, &val)
+        self.write_many(Registers::BitrateMsb, &reg.to_be_bytes())
     }
 
     /// Computes the frequency deviation, according to `fdev / Fstep` and stores it in
     /// `RegFdevMsb (0x05), RegFdevLsb (0x06)`.
     pub fn fdev(&mut self, fdev: f32) -> Result<(), Ecs, Espi> {
         let reg = (fdev / FSTEP) as u16;
-        let val = reg.to_be_bytes();
-        self.write_many(Registers::FdevMsb, &val)
+        self.write_many(Registers::FdevMsb, &reg.to_be_bytes())
     }
 
     /// Computes the radio frequency, according to `frequency / Fstep` and stores it in
     /// `RegFrfMsb (0x07), RegFrfMid (0x08), RegFrfLsb (0x09)`.
     pub fn frequency(&mut self, frequency: f32) -> Result<(), Ecs, Espi> {
         let reg = (frequency / FSTEP) as u32;
-        let val = reg.to_be_bytes();
-        self.write_many(Registers::FrfMsb, &val[1..])
+        self.write_many(Registers::FrfMsb, &reg.to_be_bytes()[1..])
     }
 
     /// Stores DIO mapping for different RFM69 modes. For DIO behavior between modes
@@ -170,8 +167,7 @@ where
     /// Sets preamble length in corresponding registers `RegPreambleMsb (0x2C),
     /// RegPreambleLsb (0x2D)`.
     pub fn preamble(&mut self, reg: u16) -> Result<(), Ecs, Espi> {
-        let val = reg.to_be_bytes();
-        self.write_many(Registers::PreambleMsb, &val)
+        self.write_many(Registers::PreambleMsb, &reg.to_be_bytes())
     }
 
     /// Sets sync config and sync words in `RegSyncConfig (0x2E), RegSyncValue1-8(0x2F-0x36)`.
@@ -202,8 +198,7 @@ where
         }
         reg |=
             packet_config.dc as u8 | packet_config.filtering as u8 | (packet_config.crc as u8) << 4;
-        let val = [reg, len];
-        self.write_many(Registers::PacketConfig1, &val)?;
+        self.write_many(Registers::PacketConfig1, &[reg, len])?;
         reg = packet_config.interpacket_rx_delay as u8 | (packet_config.auto_rx_restart as u8) << 1;
         self.update(Registers::PacketConfig2, |r| r & 0x0d | reg)
     }
@@ -349,8 +344,7 @@ where
                 }
             }
         }
-        let val = reg.to_be_bytes();
-        self.write_many(Registers::DioMapping1, &val)
+        self.write_many(Registers::DioMapping1, &reg.to_be_bytes())
     }
 
     fn reset_fifo(&mut self) -> Result<(), Ecs, Espi> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,7 +3,7 @@
 use crate::registers::*;
 use crate::*;
 use embedded_hal::blocking::delay::DelayMs;
-use embedded_hal::blocking::spi::Transfer;
+use embedded_hal::blocking::spi::{Transfer, Write};
 use embedded_hal::digital::v2::OutputPin;
 
 use std::prelude::v1::*;
@@ -36,6 +36,15 @@ impl Transfer<u8> for SpiMock {
             *val = self.tx_buffer[index];
         }
         Ok(words)
+    }
+}
+
+impl Write<u8> for SpiMock {
+    type Error = ();
+
+    fn write(&mut self, words: &[u8]) -> std::result::Result<(), Self::Error> {
+        self.rx_buffer.extend_from_slice(words);
+        Ok(())
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -304,7 +304,7 @@ fn test_preamble() {
 fn test_sync() {
     let mut rfm = setup_rfm(Vec::new(), vec![0b1_0_000_000, 0, 0]);
 
-    rfm.sync(&mut []).ok().unwrap();
+    rfm.sync(&[]).ok().unwrap();
     assert_eq!(
         rfm.spi.rx_buffer[0..=3],
         [
@@ -316,7 +316,7 @@ fn test_sync() {
     );
 
     rfm.spi.rx_buffer.clear();
-    rfm.sync(&mut [0x12, 0x34, 0x56]).ok().unwrap();
+    rfm.sync(&[0x12, 0x34, 0x56]).ok().unwrap();
     assert_eq!(
         rfm.spi.rx_buffer[0..=5],
         [
@@ -329,7 +329,7 @@ fn test_sync() {
         ]
     );
 
-    rfm.sync(&mut [0; 9]).err().unwrap();
+    rfm.sync(&[0; 9]).err().unwrap();
 }
 
 #[test]
@@ -442,7 +442,7 @@ fn test_aes() {
         vec![0b0000000_1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     );
 
-    rfm.aes(&mut []).ok().unwrap();
+    rfm.aes(&[]).ok().unwrap();
     assert_eq!(
         rfm.spi.rx_buffer[0..=3],
         [
@@ -468,8 +468,8 @@ fn test_aes() {
     );
     assert_eq!(rfm.spi.rx_buffer[5..=20], *b"1234567890abcdef");
 
-    rfm.aes(&mut [0; 14]).err().unwrap();
-    rfm.aes(&mut [0; 17]).err().unwrap();
+    rfm.aes(&[0; 14]).err().unwrap();
+    rfm.aes(&[0; 17]).err().unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Using the spi::Write trait, we can make some buffers non-mut. For example, send no longer overwrites the packet buffer.