### PR TITLE
Make read and write functions public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,6 +335,18 @@ where
         )
     }
 
+    /// Direct write to RFM69 registers.
+    pub fn write(&mut self, reg: Registers, val: u8) -> Result<(), Ecs, Espi> {
+        self.write_many(reg, &[val])
+    }
+
+    /// Direct read from RFM69 registers.
+    pub fn read(&mut self, reg: Registers) -> Result<u8, Ecs, Espi> {
+        let mut buffer = [0u8; 1];
+        self.read_many(reg, &mut buffer)?;
+        Ok(buffer[0])
+    }
+
     fn dio(&mut self) -> Result<(), Ecs, Espi> {
         let mut reg = 0x07;
         for opt_mapping in self.dio.iter() {
@@ -388,22 +400,12 @@ where
         self.write(reg, f(val))
     }
 
-    fn write(&mut self, reg: Registers, val: u8) -> Result<(), Ecs, Espi> {
-        self.write_many(reg, &[val])
-    }
-
     fn write_many(&mut self, reg: Registers, data: &[u8]) -> Result<(), Ecs, Espi> {
         let mut guard = CsGuard::new(&mut self.cs);
         guard.select()?;
         self.spi.write(&[reg.write()]).map_err(Error::Spi)?;
         self.spi.write(data).map_err(Error::Spi)?;
         Ok(())
-    }
-
-    fn read(&mut self, reg: Registers) -> Result<u8, Ecs, Espi> {
-        let mut buffer = [0u8; 1];
-        self.read_many(reg, &mut buffer)?;
-        Ok(buffer[0])
     }
 
     fn read_many(&mut self, reg: Registers, buffer: &mut [u8]) -> Result<(), Ecs, Espi> {


### PR DESCRIPTION
Some use cases are not covered by this library.

Make read and write functions public, this allows
any user to configure anything that is not implemented
yet (Some corner cases might not be covered for a long
or ever).