### PR TITLE
allow sending and receiving large packets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub enum Error<Ecs, Espi> {
     SyncSize,
     // Packet size is longer than receive buffer
     BufferTooSmall,
-    // Packet exceeds maximum size (255 for send_large, 63 for send)
+    // Packet exceeds maximum size (255 for send_large)
     PacketTooLarge,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,7 +289,7 @@ where
 
             self.mode(Mode::Standby)?;
             self.rssi = self.read(Registers::RssiValue)? as f32 / -2.0;
-            return Err(Error::PacketTooLarge);
+            return Err(Error::BufferTooSmall);
         }
 
         for b in &mut buffer[0..len] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,7 +270,7 @@ where
     /// This function is designed to receive packets larger than the FIFO size by reading data
     /// from the FIFO as soon as it is available. This can only be used with Variable(255) packet
     /// format and node address and CRC filtering disabled.
-    /// Returns `PacketTooLarge` and discards the packet if the received length byte is larger
+    /// Returns `BufferTooSmall` and discards the packet if the received length byte is larger
     /// than the buffer size.
     ///
     /// ## Note

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::blocking::spi::{Transfer, Write};
 use embedded_hal::digital::v2::OutputPin;
 
-use core::marker::PhantomData;
+use core::{cmp::min, convert::TryInto, marker::PhantomData};
 
 use crate::registers::{
     ContinuousDagc, DataMode, DccCutoff, DioMapping, DioPin, FifoMode, InterPacketRxDelay,
@@ -259,6 +259,38 @@ where
         Ok(())
     }
 
+    /// Receive bytes from another RFM69. This call blocks until there are any
+    /// bytes available. This can be combined with DIO interrupt for `SyncAddressMatch`, calling
+    /// `recv_large` immediately after the interrupt will not block waiting for packets. It will
+    /// still block until all data are received.
+    /// This function is designed to receive packets larger than the FIFO size by reading `chunk_size`
+    /// bytes at a time as soon as the `FifoThreshold` IRQ flag is set.
+    /// `CrcAutoClearOff` must be set, and `chunk_size` must not exceed `FifoThreshold + 1`.
+    pub fn recv_large(&mut self, chunk_size: usize, buffer: &mut [u8]) -> Result<usize, Ecs, Espi> {
+        if buffer.is_empty() {
+            return Ok(0);
+        }
+
+        self.reset_fifo()?;
+
+        self.mode(Mode::Receiver)?;
+        self.wait_mode_ready()?;
+
+        while !self.is_sync_address_match()? {}
+
+        while self.is_fifo_empty()? {}
+        let len: usize = self.read(Registers::Fifo)?.into();
+
+        for chunk in buffer[0..len].chunks_mut(chunk_size) {
+            self.wait_until_fifo_exceeds_threshold_or_payload_ready()?;
+            self.read_many(Registers::Fifo, chunk)?;
+        }
+
+        self.mode(Mode::Standby)?;
+        self.rssi = self.read(Registers::RssiValue)? as f32 / -2.0;
+        Ok(len)
+    }
+
     /// Send bytes to another RFM69. This can block until all data are send.
     pub fn send(&mut self, buffer: &[u8]) -> Result<(), Ecs, Espi> {
         if buffer.is_empty() {
@@ -275,6 +307,53 @@ where
         self.wait_packet_sent()?;
 
         self.mode(Mode::Standby)
+    }
+
+    /// Send bytes to another RFM69. This will block until all data are send.
+    /// This function is designed to send packets larger than the FIFO size by writing `chunk_size`
+    /// bytes at a time as soon as the `FifoThreshold` IRQ flag is cleared. The first write will have
+    /// a size of either `prefill` or the length of the packet plus the length byte, whichever is smaller.
+    /// `FifoThreshold + chunk_size` must not exceed the FIFO size (66 bytes).
+    pub fn send_large(
+        &mut self,
+        prefill: usize,
+        chunk_size: usize,
+        buffer: &[u8],
+    ) -> Result<(), Ecs, Espi> {
+        if buffer.is_empty() {
+            return Ok(());
+        }
+
+        self.mode(Mode::Standby)?;
+        self.wait_mode_ready()?;
+
+        self.reset_fifo()?;
+
+        self.write(Registers::Fifo, buffer.len().try_into().unwrap())?;
+
+        let first_chunk_size = min(prefill - 1, buffer.len());
+
+        self.write_many(Registers::Fifo, &buffer[..first_chunk_size])?;
+        self.mode(Mode::Transmitter)?;
+
+        for i in buffer[first_chunk_size..].chunks(chunk_size) {
+            self.wait_while_fifo_exceeds_threshold()?;
+            self.write_many(Registers::Fifo, i)?;
+        }
+
+        self.wait_packet_sent()?;
+
+        self.mode(Mode::Standby)
+    }
+
+    /// Check if IRQ flag SyncAddressMatch is set.
+    pub fn is_sync_address_match(&mut self) -> Result<bool, Ecs, Espi> {
+        Ok(self.read(Registers::IrqFlags1)? & 0x01 != 0)
+    }
+
+    /// Check if IRQ flag FifoNotEmpty is cleared.
+    pub fn is_fifo_empty(&mut self) -> Result<bool, Ecs, Espi> {
+        Ok(self.read(Registers::IrqFlags2)? & 0x40 == 0)
     }
 
     /// Check if IRQ flag PacketReady is set.
@@ -391,6 +470,24 @@ where
         self.with_timeout(100, 5, |rfm| {
             Ok((rfm.read(Registers::IrqFlags2)? & 0x08) != 0)
         })
+    }
+
+    fn wait_while_fifo_exceeds_threshold(&mut self) -> Result<(), Ecs, Espi> {
+        for _ in 0..1000 {
+            if self.read(Registers::IrqFlags2)? & 0x20 == 0 {
+                return Ok(());
+            }
+        }
+        Err(Error::Timeout)
+    }
+
+    fn wait_until_fifo_exceeds_threshold_or_payload_ready(&mut self) -> Result<(), Ecs, Espi> {
+        for _ in 0..1000 {
+            if self.read(Registers::IrqFlags2)? & 0x24 != 0 {
+                return Ok(());
+            }
+        }
+        Err(Error::Timeout)
     }
 
     fn with_timeout<F>(&mut self, timeout: u8, step: u8, func: F) -> Result<(), Ecs, Espi>


### PR DESCRIPTION
So here's an attempt to implement send/recv for large packets (#18). I tested it with all packet lengths from 1 to 144 bytes, but of course the FIFO threshold, bitrate, SPI clock and latency will have an influence. A few issues remain:

- Looking at my SDR, it seems that some extra bytes are sent, as if packet length is rounded up to a multiple of `chunk_size`. I haven't investigated this further.
- The interface is different from `send`/`recv` because the length byte is automatically included. I think this makes sense because the receive function needs to know it.
- I don't see how to make it work without `CrcAutoClearOff`.
- `wait_while_fifo_exceeds_threshold` etc use a crude timeout method to avoid extra delays.
- The interface is rather awkward, with the `prefill` and `chunk_size` extra parameters for `send_large`.
- It's rather complex.

Do you think these can be overcome and we can merge it? With the public register access methods, this could also be nicely implemented in the application code. What are your thoughts?