### PR TITLE
Work better with linux_embedded_hal

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -78,6 +78,22 @@ fn test_read_all_regs() {
 }
 
 #[test]
+fn test_read_all_regs_write_transfer() {
+    let mut rfm = Rfm69::new_write_transfer(
+        SpiMock {
+            rx_buffer: Vec::new(),
+            tx_buffer: (1..=0x4f).collect(),
+        },
+        NoCs,
+        DelayMock,
+    );
+
+    let result = rfm.read_all_regs().unwrap_or([0; 0x4f]);
+    assert_eq!(rfm.spi.0.rx_buffer[0], Registers::OpMode.read());
+    assert_eq!(result.as_ref(), rfm.spi.0.tx_buffer.as_slice());
+}
+
+#[test]
 fn test_mode() {
     let mut rfm = setup_rfm(Vec::new(), vec![0b111_001_11, 0]);
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -59,11 +59,12 @@ impl DelayMs<u8> for DelayMock {
 }
 
 fn setup_rfm(rx_buffer: Vec<u8>, tx_buffer: Vec<u8>) -> Rfm69<NoCs, SpiMock, DelayMock> {
-    Rfm69::new_without_cs(
+    Rfm69::new(
         SpiMock {
             rx_buffer,
             tx_buffer,
         },
+        NoCs,
         DelayMock,
     )
 }
@@ -78,13 +79,12 @@ fn test_read_all_regs() {
 }
 
 #[test]
-fn test_read_all_regs_write_transfer() {
-    let mut rfm = Rfm69::new_write_transfer(
+fn test_read_all_regs_transactional() {
+    let mut rfm = Rfm69::new_without_cs(
         SpiMock {
             rx_buffer: Vec::new(),
             tx_buffer: (1..=0x4f).collect(),
         },
-        NoCs,
         DelayMock,
     );
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -59,17 +59,13 @@ impl DelayMs<u8> for DelayMock {
 }
 
 fn setup_rfm(rx_buffer: Vec<u8>, tx_buffer: Vec<u8>) -> Rfm69<NoCs, SpiMock, DelayMock> {
-    Rfm69 {
-        spi: SpiMock {
+    Rfm69::new_without_cs(
+        SpiMock {
             rx_buffer,
             tx_buffer,
         },
-        cs: NoCs,
-        delay: DelayMock,
-        mode: Mode::Standby,
-        dio: [None; 6],
-        rssi: 0.0,
-    }
+        DelayMock,
+    )
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,23 +4,8 @@ use crate::registers::*;
 use crate::*;
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::blocking::spi::{Transactional, Transfer, Write};
-use embedded_hal::digital::v2::OutputPin;
 
 use std::prelude::v1::*;
-
-struct OutputPinMock;
-
-impl OutputPin for OutputPinMock {
-    type Error = ();
-
-    fn set_low(&mut self) -> std::result::Result<(), Self::Error> {
-        Ok(())
-    }
-
-    fn set_high(&mut self) -> std::result::Result<(), Self::Error> {
-        Ok(())
-    }
-}
 
 struct SpiMock {
     rx_buffer: Vec<u8>,
@@ -73,13 +58,13 @@ impl DelayMs<u8> for DelayMock {
     fn delay_ms(&mut self, _: u8) {}
 }
 
-fn setup_rfm(rx_buffer: Vec<u8>, tx_buffer: Vec<u8>) -> Rfm69<OutputPinMock, SpiMock, DelayMock> {
+fn setup_rfm(rx_buffer: Vec<u8>, tx_buffer: Vec<u8>) -> Rfm69<NoCs, SpiMock, DelayMock> {
     Rfm69 {
         spi: SpiMock {
             rx_buffer,
             tx_buffer,
         },
-        cs: OutputPinMock,
+        cs: NoCs,
         delay: DelayMock,
         mode: Mode::Standby,
         dio: [None; 6],


### PR DESCRIPTION
Using SPI transactions for reading and writing registers prevents `spidev` from releasing the CS line in the middle. Also added a constructor which doesn't take a CS pin, because when using `linux_embedded_hal` `spidev` manages it automatically.

Fixes #26.