### PR TITLE
Make wait for ready and send public available

### DIFF
--- a/src/rfm.rs
+++ b/src/rfm.rs
@@ -403,13 +403,15 @@ where
         self.spi.read_many(reg, buffer).map_err(Error::Spi)
     }
 
-    pub(crate) fn wait_mode_ready(&mut self) -> Result<(), Ecs, Espi> {
+    /// Wait for device is ready
+    pub fn wait_mode_ready(&mut self) -> Result<(), Ecs, Espi> {
         self.with_timeout(100, 5, |rfm| {
             Ok((rfm.read(Registers::IrqFlags1)? & 0x80) != 0)
         })
     }
 
-    pub(crate) fn wait_packet_sent(&mut self) -> Result<(), Ecs, Espi> {
+    /// Wait for packed send
+    pub fn wait_packet_sent(&mut self) -> Result<(), Ecs, Espi> {
         self.with_timeout(100, 5, |rfm| {
             Ok((rfm.read(Registers::IrqFlags2)? & 0x08) != 0)
         })


### PR DESCRIPTION
I changed wait_mode_ready and wait_packet_sent to public so that it is possible to implement custom recv and send methods.
This is required on ESP to give the IDLE task the possibility to feed the watchdog, because the standard recv function is blocking and randomly the watchdog is triggert because the IDLE task hangs.