### PR TITLE
Optionally implement std::error::Error for Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ anyhow = "1.0"
 embedded-hal-bus = { version = "0.1.0", features = ["std"] }
 linux-embedded-hal = "0.4.0"
 utilities = { path = "utilities" }
+
+[features]
+default = []
+std = []

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use core::fmt::{self, Display, Formatter};
+use core::fmt::{self, Debug, Display, Formatter};
 
 pub(crate) type Result<T, Espi> = core::result::Result<T, Error<Espi>>;
 
@@ -30,3 +30,6 @@ impl<Espi: Display> Display for Error<Espi> {
         }
     }
 }
+
+#[cfg(feature = "std")]
+impl<Espi: Display + Debug> std::error::Error for Error<Espi> {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 pub(crate) type Result<T, Espi> = core::result::Result<T, Error<Espi>>;
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Error<Espi> {
     /// SPI bus error
     Spi(Espi),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use core::fmt::{self, Display, Formatter};
+
 pub(crate) type Result<T, Espi> = core::result::Result<T, Error<Espi>>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -6,7 +8,7 @@ pub enum Error<Espi> {
     Spi(Espi),
     /// Timeout exceeded
     Timeout,
-    /// Aes key size is too big
+    /// AES key size is too big
     AesKeySize,
     /// Sync sequence is too long
     SyncSize,
@@ -14,4 +16,17 @@ pub enum Error<Espi> {
     BufferTooSmall,
     /// Packet exceeds maximum size (255 for send_large)
     PacketTooLarge,
+}
+
+impl<Espi: Display> Display for Error<Espi> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Error::Spi(espi) => write!(f, "SPI bus error: {}", espi),
+            Error::Timeout => write!(f, "Timeout exceeded."),
+            Error::AesKeySize => write!(f, "AES key size is too big."),
+            Error::SyncSize => write!(f, "Sync sequence is too long."),
+            Error::BufferTooSmall => write!(f, "Packet size is longer than receive buffer."),
+            Error::PacketTooLarge => write!(f, "Packet exceeds maximum size."),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! - [Product page](https://www.hoperf.com/modules/rf_transceiver/RFM69HCW.html)
 //! - [Datasheet](https://www.hoperf.com/data/upload/portal/20190307/RFM69HCW-V1.1.pdf)
 
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 
 pub use crate::defaults::low_power_lab_defaults;
 pub use crate::error::Error;


### PR DESCRIPTION
This makes error handling easier when `std` is available, but is guarded behind a new feature `std`, to avoid pulling in the dependency for users who don't want it.

Also implemented `Display`, `Debug`, `Clone` and `Eq`.