### PR TITLE
Add High Power Feature for RFM69HCW

### DIFF
--- a/src/registers.rs
+++ b/src/registers.rs
@@ -447,3 +447,9 @@ impl core::ops::BitAnd<IrqFlags2> for u8 {
         self & rhs as Self
     }
 }
+
+pub enum PaOptions {
+    Pa0On = 0x80,
+    Pa1On = 0x40,
+    Pa2On = 0x20,
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -500,3 +500,51 @@ fn test_is_packet_sent() {
     assert!(rfm.is_packet_sent().ok().unwrap());
     assert_eq!(rfm.spi.rx_buffer[0], Registers::IrqFlags2.read());
 }
+
+// Test Tx Level
+
+#[test]
+fn test_tx_level_high_pwr_min() {
+    // high power min is -2
+    let mut rfm = setup_rfm(Vec::new(), vec![]);
+    assert!(rfm.tx_level_high_pwr(-3).is_ok());
+    assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x50]);
+}
+
+#[test]
+fn test_tx_level_hp_max() {
+    // high power max is 20
+    let mut rfm = setup_rfm(Vec::new(), vec![]);
+    assert!(rfm.tx_level_high_pwr(21).is_ok());
+    assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x7f]);
+}
+
+#[test]
+fn test_tx_level_hp_mid() {
+    let mut rfm = setup_rfm(Vec::new(), vec![]);
+    assert!(rfm.tx_level_high_pwr(15).is_ok());
+    assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x7d]);
+}
+
+#[test]
+fn test_tx_level_lp_min() {
+    // Low Power min is -18
+    let mut rfm = setup_rfm(Vec::new(), vec![]);
+    assert!(rfm.tx_level(-19).is_ok());
+    assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x80]);
+}
+
+#[test]
+fn test_tx_level_lp_max() {
+    // Low power max is 13
+    let mut rfm = setup_rfm(Vec::new(), vec![]);
+    assert!(rfm.tx_level(14).is_ok());
+    assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x9f]);
+}
+
+#[test]
+fn test_tx_level_lp_mid() {
+    let mut rfm = setup_rfm(Vec::new(), vec![]);
+    assert!(rfm.tx_level(0).is_ok());
+    assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x92]);
+}


### PR DESCRIPTION
#4 Add High Power
[Datasheet](https://www.digikey.com/htmldatasheets/production/1921186/0/0/1/rfm69hcw.html)

* Added tx_level and tx_level_high_pwr methods to the rfm69 struct

* Added enable_boost_mode and disable_boost_mode methods to enable and disable the high power transmit settings during transmissions where the tx level is >= 18